### PR TITLE
Fix incorrect usage of Timer.Reset, honour Context deadlines, avoid leaking timers

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -144,9 +144,11 @@ func (c *rootCommand) stopLoggers() {
 		close(done)
 	}()
 	close(c.stopLoggersCh)
+	timer := time.NewTimer(waitLoggerCloseTimeout)
+	defer timer.Stop()
 	select {
 	case <-done:
-	case <-time.After(waitLoggerCloseTimeout):
+	case <-timer.C:
 		c.globalState.FallbackLogger.Errorf("The logger didn't stop in %s", waitLoggerCloseTimeout)
 	}
 }

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -336,10 +336,10 @@ func showProgress(ctx context.Context, gs *state.GlobalState, pbs []*pb.Progress
 	}
 
 	ticker := time.NewTicker(updateFreq)
-	ctxDone := ctx.Done()
+	defer ticker.Stop()
 	for {
 		select {
-		case <-ctxDone:
+		case <-ctx.Done():
 			renderProgressBars(false)
 			gs.OutMutex.Lock()
 			printProgressBars()

--- a/js/modules/k6/ws/ws.go
+++ b/js/modules/k6/ws/ws.go
@@ -425,8 +425,10 @@ func (s *Socket) SetTimeout(fn goja.Callable, timeoutMs float64) error {
 		return fmt.Errorf("setTimeout requires a >0 timeout parameter, received %.2f", timeoutMs)
 	}
 	go func() {
+		timer := time.NewTimer(d)
+		defer timer.Stop()
 		select {
-		case <-time.After(d):
+		case <-timer.C:
 			select {
 			case s.scheduled <- fn:
 			case <-s.done:
@@ -475,7 +477,7 @@ func (s *Socket) SetInterval(fn goja.Callable, intervalMs float64) error {
 	return nil
 }
 
-// Close closes the webscocket. If providede the first argument will be used as the code for the close message.
+// Close closes the webscocket. If provided, the first argument will be used as the code for the close message.
 func (s *Socket) Close(args ...goja.Value) {
 	code := websocket.CloseGoingAway
 	if len(args) > 0 {

--- a/js/runner.go
+++ b/js/runner.go
@@ -814,8 +814,10 @@ func (u *ActiveVU) RunOnce() error {
 	if isFullIteration && u.Runner.Bundle.Options.MinIterationDuration.Valid {
 		durationDiff := u.Runner.Bundle.Options.MinIterationDuration.TimeDuration() - totalTime
 		if durationDiff > 0 {
+			timer := time.NewTimer(durationDiff)
+			defer timer.Stop()
 			select {
-			case <-time.After(durationDiff):
+			case <-timer.C:
 			case <-u.RunContext.Done():
 			}
 		}

--- a/lib/executor/constant_arrival_rate.go
+++ b/lib/executor/constant_arrival_rate.go
@@ -313,8 +313,7 @@ func (car ConstantArrivalRate) Run(parentCtx context.Context, out chan<- metrics
 	}
 
 	start, offsets, _ := car.et.GetStripedOffsets()
-	timer := time.NewTimer(time.Hour * 24)
-	// here the we need the not scaled one
+	// Here we need the not scaled one.
 	notScaledTickerPeriod := getTickerPeriod(
 		big.NewRat(
 			car.config.Rate.Int64,
@@ -326,7 +325,8 @@ func (car ConstantArrivalRate) Run(parentCtx context.Context, out chan<- metrics
 	metricTags := car.getMetricTags(nil)
 	for li, gi := 0, start; ; li, gi = li+1, gi+offsets[li%len(offsets)] {
 		t := notScaledTickerPeriod*time.Duration(gi) - time.Since(startTime)
-		timer.Reset(t)
+
+		timer := time.NewTimer(t)
 		select {
 		case <-timer.C:
 			if vusPool.TryRunIteration() {
@@ -362,6 +362,7 @@ func (car ConstantArrivalRate) Run(parentCtx context.Context, out chan<- metrics
 			}
 
 		case <-regDurationCtx.Done():
+			timer.Stop()
 			return nil
 		}
 	}

--- a/lib/executor/ramping_arrival_rate.go
+++ b/lib/executor/ramping_arrival_rate.go
@@ -436,7 +436,6 @@ func (varr RampingArrivalRate) Run(parentCtx context.Context, out chan<- metrics
 	}
 
 	regDurationDone := regDurationCtx.Done()
-	timer := time.NewTimer(time.Hour)
 	start := time.Now()
 	ch := make(chan time.Duration, 10) // buffer 10 iteration times ahead
 	var prevTime time.Duration
@@ -453,10 +452,11 @@ func (varr RampingArrivalRate) Run(parentCtx context.Context, out chan<- metrics
 		prevTime = nextTime
 		b := time.Until(start.Add(nextTime))
 		if b > 0 { // TODO: have a minimal ?
-			timer.Reset(b)
+			timer := time.NewTimer(b)
 			select {
 			case <-timer.C:
 			case <-regDurationDone:
+				timer.Stop()
 				return nil
 			}
 		}

--- a/lib/executor/ramping_vus.go
+++ b/lib/executor/ramping_vus.go
@@ -692,11 +692,11 @@ func (rs *rampingVUsRunState) scheduledVUsHandlerStrategy() func(lib.ExecutionSt
 // TODO set start here?
 // TODO move it to a struct type or something and benchmark if that makes a difference
 func waiter(ctx context.Context, start time.Time) func(offset time.Duration) bool {
-	timer := time.NewTimer(time.Hour * 24)
 	return func(offset time.Duration) bool {
 		diff := offset - time.Since(start)
 		if diff > 0 { // wait until time of event arrives // TODO have a mininum
-			timer.Reset(diff)
+			timer := time.NewTimer(diff)
+			defer timer.Stop()
 			select {
 			case <-ctx.Done():
 				return true // exit if context is cancelled

--- a/lib/netext/httpext/request_test.go
+++ b/lib/netext/httpext/request_test.go
@@ -533,10 +533,10 @@ func TestMakeRequestRPSLimit(t *testing.T) {
 	}
 
 	timer := time.NewTimer(3 * time.Second)
+	defer timer.Stop()
 	for {
 		select {
 		case <-timer.C:
-			timer.Stop()
 			val := atomic.LoadInt64(&requests)
 			assert.NotEmpty(t, val)
 			assert.InDelta(t, val, 3, 3)

--- a/lib/testutils/grpcservice/service.go
+++ b/lib/testutils/grpcservice/service.go
@@ -38,11 +38,18 @@ func NewFeatureExplorerServer(features ...*Feature) *FeatureExplorerImplementati
 }
 
 // GetFeature returns the feature at the given point.
-func (s *FeatureExplorerImplementation) GetFeature(_ context.Context, point *Point) (*Feature, error) {
+func (s *FeatureExplorerImplementation) GetFeature(ctx context.Context, point *Point) (*Feature, error) {
 	s.Logf("GetFeature called with: %+v\n", point)
 
 	n := rand.Intn(1000) //nolint:gosec
-	time.Sleep(time.Duration(n) * time.Millisecond)
+
+	timer := time.NewTimer(time.Duration(n) * time.Millisecond)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 
 	for _, feature := range s.savedFeatures {
 		if proto.Equal(feature.Location, point) {

--- a/output/cloud/expv2/output.go
+++ b/output/cloud/expv2/output.go
@@ -181,11 +181,9 @@ func (o *Output) StopWithTestError(_ error) error {
 }
 
 func (o *Output) runPeriodicFlush() {
-	t := time.NewTicker(o.config.MetricPushInterval.TimeDuration())
-
 	o.wg.Add(1)
-
 	go func() {
+		t := time.NewTicker(o.config.MetricPushInterval.TimeDuration())
 		defer func() {
 			t.Stop()
 			o.wg.Done()


### PR DESCRIPTION
## What?

TODO: open this PR in the upstream repo after reviewing the contribution guidelines. 

I came across this while going through the codebase.

This changelist includes three changes:
- Fix incorrect usage of `Timer.Reset`.
- Honour Context deadlines, including for `http.Request`.
- Avoid leaking timers.

There are a few places in the codebase where `Timer.Reset` is being called right before attempting to receive from the
`Timer.C` channel. If the timer has already fired, this can lead to a receive from `Timer.C` returning earlier than
the duration supplied to `Timer.Reset` as `Reset` does not drain the `Timer.C` channel.

Here's an example to demonstrate this:

```golang
timer := time.NewTimer(100 * time.Millisecond)
time.Sleep(200 * time.Millisecond)
timer.Reset(24 * time.Hour)
select {
case <-time.After(1 * time.Millisecond):
case <-timer.C:
  panic("fired before 24 hours")
}
```

It's not advisable to call `Timer.Reset` while it's still active on a `Timer` obtained from a call to `time.NewTimer`,
as mentioned in the [docs](https://pkg.go.dev/time#Timer.Reset). The correct usage is to call `Reset` only on timers
that are stopped or have had their channels drained.

This changelist fixes the issue by creating a new `Timer` before waiting on `Timer.C`, and `Stop`ping it before the function returns.


## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
